### PR TITLE
Added the .devcontainer directory

### DIFF
--- a/.devcontainer/python/devcontainer.json
+++ b/.devcontainer/python/devcontainer.json
@@ -1,0 +1,36 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/python:3.12",
+    "remoteUser": "vscode",
+    "postCreateCommand": "sudo apt-get update && sudo apt-get install -y python3-numpy python3-scipy python3-ipykernel && pip install flake8 pycodestyle_magic ",
+    "features": {
+      "ghcr.io/devcontainers/features/common-utils:2": {
+        "configureZshAsDefaultShell": true
+      },
+      "ghcr.io/devcontainers/features/python:1": {
+          "toolsToInstall": [
+            "flake8",
+            "autopep8",
+            "black",
+            "yapf",
+            "mypy",
+            "pydocstyle",
+            "pycodestyle",
+            "bandit",
+            "pipenv",
+            "virtualenv",
+            "pytest",
+            "pylint"
+          ]
+      }
+    },
+    "customizations": {
+      "vscode": {
+        "extensions": [
+          "ms-toolsai.jupyter",
+          "ms-toolsai.vscode-jupyter-cell-tags",
+          "ms-python.python",
+          "DavidAnson.vscode-markdownlint"
+        ]
+      }
+    }
+  }


### PR DESCRIPTION
A .devcontainer directory was re-added to set up the codespace for Python after pull-request #17 was reverted for containing irrelevant files to the description.

It was adopted from: https://github.com/ubsuny/CompPhys/blob/main/.devcontainer/python/devcontainer.json