### PR TITLE
Added the exception handling for Broadcasting

### DIFF
--- a/BroadcastingInMultiplication.py
+++ b/BroadcastingInMultiplication.py
@@ -62,9 +62,6 @@ def arrayMultiplication1(arr1, arr2):
         errmsg = "Incompatible shapes: " + str(e)
         return errmsg
 
-    result = np.einsum(arr2, [Ellipsis], arr1, [Ellipsis])
-    return result
-
     broadcasted_arr2 = np.broadcast_to(arr1,arr2.shape)
 
     result = arr1 * broadcasted_arr2 # instead of arr2
@@ -106,7 +103,7 @@ def arrayMultiplication3(arr1, arr2):
         errmsg = "Incompatible shapes: " + str(e)
         return errmsg
 
-    result = np.einsum(arr2, [Ellipsis], arr1, [Ellipsis])
+    result = np.einsum(arr2, [Ellipsis], arr1, [Ellipsis]) # Default NumPy-style broadcasting is done by adding an ellipsis to the left of each term
     return result
 
 # testing

--- a/BroadcastingInMultiplication.py
+++ b/BroadcastingInMultiplication.py
@@ -53,9 +53,19 @@ def arrayMultiplication1(arr1, arr2):
     Returns:
     ndarray: An array of the elements that each of them result from multiplying an element from the first array by an element from the second array
     """
+    # Exception Handling (for when the two arrays cannot be matched in shape)
+    try:
+        broadcast_shape = np.broadcast_shapes(arr1.shape, arr2.shape)
+        # If the shapes are compatible, NumPy will return the resulting broadcast shape. If not, it will raise a ValueError.
+        # print("Broadcastable to shape:", broadcast_shape) [this is not needed]
+    except ValueError as e:
+        errmsg = "Incompatible shapes: " + str(e)
+        return errmsg
+
+    result = np.einsum(arr2, [Ellipsis], arr1, [Ellipsis])
+    return result
 
     broadcasted_arr2 = np.broadcast_to(arr1,arr2.shape)
-
 
     result = arr1 * broadcasted_arr2 # instead of arr2
     return result
@@ -87,6 +97,14 @@ def arrayMultiplication3(arr1, arr2):
     Returns:
     ndarray: An array of the elements that each of them result from multiplying an element from the first array by an element from the second array
     """
+    # Exception Handling (for when the two arrays cannot be matched in shape)
+    try:
+        broadcast_shape = np.broadcast_shapes(arr1.shape, arr2.shape)
+        # If the shapes are compatible, NumPy will return the resulting broadcast shape. If not, it will raise a ValueError.
+        # print("Broadcastable to shape:", broadcast_shape) [this is not needed]
+    except ValueError as e:
+        errmsg = "Incompatible shapes: " + str(e)
+        return errmsg
 
     result = np.einsum(arr2, [Ellipsis], arr1, [Ellipsis])
     return result
@@ -108,8 +126,3 @@ print("The best time taken to multiply the second array by the scalar is roughly
 print(arrayMultiplication1(arr1,arr2))
 print("The best time taken to multiply the first array by the second array is roughly: ", tm.timeit(lambda: arrayMultiplication1(arr1,arr2), number = 1000), " sec")
 
-"""
-1. There's no problem with the multiplication of an array by a scalar
-2. Not all the arrays can be broadcasted to match each other
-"""
-# TODO: An exception handling is needed to deal with the "unmatchable" scenarios


### PR DESCRIPTION
Added the exception handling to where it was needed. It was added to the first and third implementations of Broadcasting in multiplying two arrays. It handles the cases in which the two arrays that are to be multiplied have shapes that cannot be broadcasted into eachother.